### PR TITLE
Fix phantomjs installation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,4 +2,4 @@ FROM node:latest
 
 MAINTAINER Fred Cox "mcfedr@gmail.com"
 
-RUN npm install -g phantomjs-prebuilt
+RUN npm install phantomjs-prebuilt


### PR DESCRIPTION
Error:
Build failed: The command '/bin/sh -c npm install -g phantomjs-prebuilt' returned a non-zero code: 1